### PR TITLE
Don't assume http

### DIFF
--- a/app/components/gravatar-image.js
+++ b/app/components/gravatar-image.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
     var email = this.get('email'),
         size = this.get('size');
 
-    return 'http://www.gravatar.com/avatar/' + md5(email) + '?s=' + size;
+    return '//www.gravatar.com/avatar/' + md5(email) + '?s=' + size;
   }.property('email', 'size'),
 
   altText: function() {


### PR DESCRIPTION
Just use a protocol relative url. Works in all browsers, avoids mismatched protocol errors. The alternative (and not a bad one) would be to just always use `https` urls.
