### PR TITLE
[Enhancement] Update gravatar-image.js to not use prototype functions

### DIFF
--- a/app/components/gravatar-image.js
+++ b/app/components/gravatar-image.js
@@ -8,15 +8,13 @@ export default Ember.Component.extend({
   title: '',
   default: '',
 
-  src: function() {
+  src: Ember.computed('email', 'size', 'default', function() {
     var email = this.get('email'),
         size = this.get('size'),
         def = this.get('default');
 
     return '//www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
-  }.property('email', 'size', 'default'),
+  }),
 
-  alt: function() {
-    return this.get('email');
-  }.property()
+  alt: Ember.computed.alias('email')
 });


### PR DESCRIPTION
This is needed for those with prototypes turned off.  Also, `alt` was not observing `email` so the computed was not updated if `email` changed.

http://emberjs.com/guides/configuring-ember/disabling-prototype-extensions/
