### PR TITLE
Optional secure URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ember g ember-cli-gravatar
 __An example with multiple options:__
 
 ```hbs
-{{gravatar-image email='johnotander@gmail.com' alt='John Otander gravatar' size=250 default='identicon' class='img-circle'}}
+{{gravatar-image email='johnotander@gmail.com' alt='John Otander gravatar' size=250 default='identicon' class='img-circle' secure=true}}
 ```
 
 The default property is optional as well as the size. You can use a encoded url or a default icon name.
@@ -43,6 +43,7 @@ The default property is optional as well as the size. You can use a encoded url 
   * `size`
   * `default`
   * `title`
+  * `secure`
 
 ### Content Security Policy
 

--- a/addon/components/gravatar-image.js
+++ b/addon/components/gravatar-image.js
@@ -18,11 +18,11 @@ export default Ember.Component.extend({
         secure = this.get("secure"),
         protocol;
     if(secure===null){
-      protocol = ''
+      protocol = '';
     } else if (secure===false){
-      protocol = 'http:'
+      protocol = 'http:';
     } else{
-      protocol = 'https:'
+      protocol = 'https:';
     }
     return protocol + '//www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
   })

--- a/addon/components/gravatar-image.js
+++ b/addon/components/gravatar-image.js
@@ -9,12 +9,14 @@ export default Ember.Component.extend({
   email: '',
   title: '',
   default: '',
+  secure: false,
 
   src: Ember.computed('email', 'size', 'default', function() {
     var email = this.get('email'),
         size = this.get('size'),
-        def = this.get('default');
+        def = this.get('default'),
+        secure = this.get("secure");
 
-    return '//www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
+    return (secure? "https" : "http") + '://www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
   })
 });

--- a/addon/components/gravatar-image.js
+++ b/addon/components/gravatar-image.js
@@ -9,14 +9,21 @@ export default Ember.Component.extend({
   email: '',
   title: '',
   default: '',
-  secure: false,
+  secure: null,
 
   src: Ember.computed('email', 'size', 'default', function() {
     var email = this.get('email'),
         size = this.get('size'),
         def = this.get('default'),
-        secure = this.get("secure");
-
-    return (secure? "https" : "http") + '://www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
+        secure = this.get("secure"),
+        protocol;
+    if(secure===null){
+      protocol = ''
+    } else if (secure===false){
+      protocol = 'http:'
+    } else{
+      protocol = 'https:'
+    }
+    return protocol + '//www.gravatar.com/avatar/' + md5(email) + '?s=' + size + '&d=' + def;
   })
 });


### PR DESCRIPTION
This change is required because, when packaging the Ember-CLI application as a Stand-Alone Desktop application (Using tools like TideSDK), the application crashes because, it is trying to access a local file (Which obviously does not exist locally) rather than the Gravatar Site. Please refer attachment:

![screen shot 2015-04-13 at 13 35 48](https://cloud.githubusercontent.com/assets/502170/7111886/10be46f4-e1e2-11e4-95cb-9c2a92121d48.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/johnotander/ember-cli-gravatar/17)
<!-- Reviewable:end -->
