### PR TITLE
bump project dependencies

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,16 @@
   "name": "ember-cli-gravatar",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
-    "ember-resolver": "~0.1.12",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
-    "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1",
+    "ember": "1.13.10",
+    "ember-data": "1.13.10",
+    "ember-resolver": "0.1.18",
+    "loader.js": "ember-cli/loader.js#3.4.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.6",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
+    "ember-qunit": "0.4.13",
+    "ember-qunit-notifications": "0.1.0",
+    "qunit": "~1.18.0",
     "JavaScript-MD5": "~1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,19 +28,21 @@
   "dependencies": {},
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
-    "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "1.0.0",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-divshot": "^0.1.7",
-    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-htmlbars": "1.0.1",
+    "ember-cli-htmlbars-inline-precompile": "0.3.1",
+    "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.9",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
-    "ember-export-application-global": "^1.0.2"
+    "ember-cli-qunit": "1.0.3",
+    "ember-cli-uglify": "1.2.0",
+    "ember-data": "1.13.10",
+    "ember-export-application-global": "~1.0.5",
+    "ember-template-compiler": "^1.8.0",
+    "handlebars": "^1.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I checked out this repository to attempt https://github.com/johnotander/ember-cli-gravatar/issues/38, but quickly realize the project needed a version bump.

I've included ember-cli-html-bars-inline precompile so compenent tests can be written in the Ember 2.0 recommended way (as integration rather than unit tests — http://guides.emberjs.com/v2.0.0/testing/testing-components/)

Normally wouldn't submit a PR for something like this but the upgrade was quite painful... all tests are passing.