### PR TITLE
make the version of md5 explicit

### DIFF
--- a/blueprints/ember-cli-gravatar/index.js
+++ b/blueprints/ember-cli-gravatar/index.js
@@ -2,6 +2,8 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('blueimp-md5');
+    return this.addBowerPackagesToProject([
+		 {name: 'blueimp-md5', target: '2.1.0'}
+    ]);
   }
 };


### PR DESCRIPTION
I think it's a good idea to make important dependencies explicit WRT to versioning.