### PR TITLE
Fix import for nested add-on.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
   name: 'ember-cli-gravatar',
 
   included: function included(app) {
+    // workaround for https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
     this.app = app;
     this._super.included(app);
 


### PR DESCRIPTION
This PR fix import when add used in nested add-on. For example I have an add-on which requires `ember-cli-gravatar`. Without that fix it won't work when my add-on is included in the main app.