### PR TITLE
Fix view.has console errors when using has-gravatar component

### DIFF
--- a/addon/components/has-gravatar.js
+++ b/addon/components/has-gravatar.js
@@ -17,14 +17,14 @@ export default Component.extend({
     const { email, gravatar, secure } = getProperties(this, 'email', 'gravatar', 'secure');
 
     return gravatar.hasGravatar(email, secure)
-      .then((has)=> {
-        set(this, 'has', has);
+      .then((hasGravatar)=> {
+        set(this, 'hasGravatar', hasGravatar);
         set(this, 'checking', false);
       });
   },
 
   layout,
-  has: false,
+  hasGravatar: false,
   checking: true,
   email: '',
   secure: false

--- a/addon/templates/components/has-gravatar.hbs
+++ b/addon/templates/components/has-gravatar.hbs
@@ -1,6 +1,6 @@
 {{#unless checking}}
   {{yield (hash
-    has=has
+    has=hasGravatar
     image=(component 'gravatar-image' email=email secure=secure)
   )}}
 {{/unless}}


### PR DESCRIPTION
Fixes #51.

I have renamed `has` to `hasGravatar` internally on the `has-gravatar` component to keep from overwriting the view's `has` function. I was able to keep yielding as `has` so this PR will not break the established API.