### PR TITLE
fix: update babel to 6.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "blueimp-md5": "^2.7.0",
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
-    "ember-cli-babel": "^6.3.0",
+    "ember-cli-babel": "^6.14.0",
     "ember-cli-htmlbars": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Prevents a deprecation warning for babel